### PR TITLE
Fixed spacing below the last card

### DIFF
--- a/MultiROMMgr/src/main/res/layout/cards_view.xml
+++ b/MultiROMMgr/src/main/res/layout/cards_view.xml
@@ -13,7 +13,9 @@
         android:overScrollMode="never"
         android:paddingLeft="0dp"
         android:paddingRight="0dp"
-        android:scrollbars="vertical">
+        android:scrollbars="vertical"
+        android:paddingBottom="@dimen/card_padding"
+        android:clipToPadding="false">
     </com.fima.cardsui.views.QuickReturnListView>
 
     <FrameLayout


### PR DESCRIPTION
On small devices (like the Nexus 4) there wasn't any padding below the "Install Ubuntu Touch" card. Fixed that. :wink:
