### PR TITLE
OnePlus one Ubuntu touch 

### DIFF
--- a/MultiROMMgr/src/main/assets/devices.json
+++ b/MultiROMMgr/src/main/assets/devices.json
@@ -158,7 +158,8 @@
             "check_gpg": false,
             "ubuntu_touch": {
                 "enabled": false,
-                "base_url": ""
+                "base_url": "http://system-image.ubports.com",
+                "device": "bacon"
             },
             "devices": [
                 {

--- a/MultiROMMgr/src/main/java/com/tassadar/multirommgr/Device.java
+++ b/MultiROMMgr/src/main/java/com/tassadar/multirommgr/Device.java
@@ -91,6 +91,10 @@ public class Device {
         JSONObject o = info.getJSONObject("ubuntu_touch");
         m_supportsUbuntuTouch = o.getBoolean("enabled");
         m_ubuntuBaseUrl = o.optString("base_url", UbuntuManifest.DEFAULT_BASE_URL);
+        if (o.has("device")){
+            m_ubuntuDevice = o.getString("device");
+        }
+
     }
 
     public String getBootDev() { return m_devices.get("boot"); }
@@ -103,6 +107,7 @@ public class Device {
     public String getBaseVariantName() { return m_base_variant_name; }
     public boolean supportsUbuntuTouch() { return m_supportsUbuntuTouch; }
     public String getUbuntuBaseUrl() { return m_ubuntuBaseUrl; }
+    public String getUbuntuDevice() { return m_ubuntuDevice; }
     public boolean isOfficialPort() { return m_isOfficialPort; }
     public String getKexecCheckPath() { return m_kexecCheckPath; }
 
@@ -115,4 +120,5 @@ public class Device {
     private boolean m_checkGpgSignatures;
     private boolean m_isOfficialPort;
     private String m_kexecCheckPath;
+    private String m_ubuntuDevice = "";
 }

--- a/MultiROMMgr/src/main/java/com/tassadar/multirommgr/installfragment/UbuntuManifest.java
+++ b/MultiROMMgr/src/main/java/com/tassadar/multirommgr/installfragment/UbuntuManifest.java
@@ -100,12 +100,20 @@ public class UbuntuManifest {
                 // Ubuntu Touch manifests, yet the versions
                 // for flo/grouper work fine - select those.
                 String dev_name = dev.getName();
-                if(!c.hasDevice(dev_name)) {
-                    dev_name = dev.getBaseVariantName();
-
-                    if(!c.hasDevice(dev_name)) {
+                if(dev.getUbuntuDevice() != ""){
+                    dev_name = dev.getUbuntuDevice();
+                    if (!c.hasDevice(dev_name)) {
                         c_itr.remove();
                         continue;
+                    }
+                }else {
+                    if (!c.hasDevice(dev_name)) {
+                        dev_name = dev.getBaseVariantName();
+
+                        if (!c.hasDevice(dev_name)) {
+                            c_itr.remove();
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This 	adds options to specify which device name to use to install Ubuntu Touch.
&&
Adds Ubuntu Touch to device bacon, but does not Enable Ubuntu touch for bacon due to needed change in recovery.