### PR TITLE
Adding support for the Z2 tablet(s) & Updated URL for the Z2 phone

### DIFF
--- a/MultiROMMgr/src/main/assets/devices.json
+++ b/MultiROMMgr/src/main/assets/devices.json
@@ -402,7 +402,7 @@
         },
         {
             "names": [ "sirius", "D6503", "D6502", "D6506", "D6543" ],
-            "manifest_url": "http://multirom.myself5.de/sirius/manifest.json",
+            "manifest_url": "https://diewald-net.com/files/public/MultiRom/sirius/manifest.json",
             "check_gpg": false,
             "ubuntu_touch": {
                 "enabled": false,

--- a/MultiROMMgr/src/main/assets/devices.json
+++ b/MultiROMMgr/src/main/assets/devices.json
@@ -424,6 +424,52 @@
             ]
         },
         {
+            "names": [ "castor", "SGP521", "SGP541", "SGP551" ],
+            "manifest_url": "https://diewald-net.com/files/public/MultiRom/castor/manifest.json",
+            "check_gpg": false,
+            "ubuntu_touch": {
+                "enabled": false,
+                "base_url": ""
+            },
+            "devices": [
+                {
+                    "name": "recovery",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/FOTAKernel"
+                },
+                {
+                    "name": "boot",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/boot"
+                },
+                {
+                    "name": "cache",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/cache"
+                }
+            ]
+        },
+        {
+            "names": [ "castor_windy", "SGP511/B", "SGP512/B" ],
+            "manifest_url": "http://diewald-net.com/files/public/MultiRom/castor_windy/manifest.json",
+            "check_gpg": false,
+            "ubuntu_touch": {
+                "enabled": false,
+                "base_url": ""
+            },
+            "devices": [
+                {
+                    "name": "recovery",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/FOTAKernel"
+                },
+                {
+                    "name": "boot",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/boot"
+                },
+                {
+                    "name": "cache",
+                    "path": "/dev/block/platform/msm_sdcc.1/by-name/cache"
+                }
+            ]
+        },
+        {
             "names": [ "z3", "D6603", "D6602", "D6633", "D6643" ],
             "manifest_url": "http://multirom.myself5.de/z3/manifest.json",
             "check_gpg": false,


### PR DESCRIPTION
Hello Tasssadar,

I have recently ported MultiROM to the Z2 tablet (both the LTE and the WIFI version). The provided version on my server is of course tested to work correctly and the modification to the manager application are also confirmed to be alright. Hence, I would kindly ask you to integrate the commits referenced in this request.

The second commit referenced in this request is an update to the download URL for the Z2 phone, since the original maintainer of this device (Myself5)  sold his phone and we agreed that I would take over development. It is easier for the future development if the MultiROM files would be hosted on my server (Jenkins integration).

If these change are fine with you it would be great if you'd ping me when releasing an update of the application that contains these commits such that I can "release" the corresponding XDA:DB thread for the Z2 tablet.

Regards,
Alexander