### PR TITLE
Switched system-image-server for flo to point to UBports.

### DIFF
--- a/MultiROMMgr/src/main/assets/devices.json
+++ b/MultiROMMgr/src/main/assets/devices.json
@@ -3,7 +3,8 @@
         {
             "names": [ "flo" ],
             "ubuntu_touch": {
-                "enabled": true
+                "enabled": true,
+                "base_url": "http://system-image.ubports.com"
             },
             "official": true,
             "devices": [


### PR DESCRIPTION
Since UBports has their own system-image-server running with flo builds up there, here's a modified copy of devices.json that points the flo over to `http://system-image.ubports.com`

As referenced in issue #120, idk what I was doing wrong, but my edit to devices.json worked when I attempted it this time.. I must've missed a comma the first time I tried, doing this stuff at like 5am can cause that! :+1: 